### PR TITLE
fix: add database password authentication to workflows

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -73,11 +73,11 @@ jobs:
             
             if [ "$SIGNIFICANT_CHANGES" -gt 10 ]; then
               echo "❌ Significant changes detected in generated types!"
-              echo "Please run 'npm run generate-types' locally and commit the changes."
-              echo ""
-              echo "Changes detected:"
-              git diff types/database.ts
-              exit 1
+            echo "Please run 'npm run generate-types' locally and commit the changes."
+            echo ""
+            echo "Changes detected:"
+            git diff types/database.ts
+            exit 1
             else
               echo "✅ Only minor formatting differences detected (likely function argument ordering)"
               echo "This is normal with Supabase type generation. Updating types..."
@@ -87,7 +87,7 @@ jobs:
               git commit -m "ci: normalize generated types formatting [skip ci]" || echo "No changes to commit"
             fi
           else
-            echo "✅ Generated types are up to date"
+          echo "✅ Generated types are up to date"
           fi
 
       - name: Stop Supabase

--- a/.github/workflows/deploy.yml
+++ b/.github/workflows/deploy.yml
@@ -24,7 +24,7 @@ jobs:
           SUPABASE_ACCESS_TOKEN: ${{ secrets.SUPABASE_ACCESS_TOKEN }}
 
       - name: Deploy database migrations
-        run: supabase db push
+        run: supabase db push --password ${{ secrets.SUPABASE_DB_PASSWORD }}
         env:
           SUPABASE_ACCESS_TOKEN: ${{ secrets.SUPABASE_ACCESS_TOKEN }}
 

--- a/.github/workflows/publish-types.yml
+++ b/.github/workflows/publish-types.yml
@@ -57,7 +57,7 @@ jobs:
       - name: Generate types from production
         run: |
           echo "🔄 Generating types from production database..."
-          supabase gen types typescript > types/database.ts
+          supabase gen types typescript --password ${{ secrets.SUPABASE_DB_PASSWORD }} > types/database.ts
           echo "✅ Types generated successfully"
         env:
           SUPABASE_ACCESS_TOKEN: ${{ secrets.SUPABASE_ACCESS_TOKEN }}


### PR DESCRIPTION
## 🔧 Fix: Database Authentication in CI/CD Workflows

This PR fixes the database authentication issues that were causing the Deploy and Publish Types Package workflows to fail.

### 🐛 Problem
- Deploy workflow was failing with "failed SASL auth" error
- Publish Types Package workflow was being skipped due to Deploy failures
- Missing database password in workflow authentication

### ✅ Solution
- Added `--password ${{ secrets.SUPABASE_DB_PASSWORD }}` flag to `supabase db push` in deploy workflow
- Added `--password ${{ secrets.SUPABASE_DB_PASSWORD }}` flag to `supabase gen types` in publish-types workflow
- Updated both workflows to properly authenticate with production database

### 🧪 Testing
- [x] Added SUPABASE_DB_PASSWORD secret to repository
- [ ] Deploy workflow should now succeed
- [ ] Publish Types Package workflow should run after successful deploy
- [ ] NPM package should be published automatically

### 📋 Changes
- `.github/workflows/deploy.yml`: Added password authentication
- `.github/workflows/publish-types.yml`: Added password authentication

This should resolve the workflow failures and enable automatic type publishing!