### PR TITLE
fix: add --linked flag to supabase gen types commands

### DIFF
--- a/.github/workflows/deploy.yml
+++ b/.github/workflows/deploy.yml
@@ -41,7 +41,9 @@ jobs:
 
       - name: Generate and verify production types
         run: |
-          supabase gen types typescript > types/database-production.ts
+          supabase gen types typescript --linked --password ${{ secrets.SUPABASE_DB_PASSWORD }} > types/database-production.ts
           echo "✅ Production types generated successfully"
           # Note: We don't commit these back as they should match the committed types
           # This step is mainly for verification that production schema matches expectations
+        env:
+          SUPABASE_ACCESS_TOKEN: ${{ secrets.SUPABASE_ACCESS_TOKEN }}

--- a/.github/workflows/publish-types.yml
+++ b/.github/workflows/publish-types.yml
@@ -57,7 +57,7 @@ jobs:
       - name: Generate types from production
         run: |
           echo "🔄 Generating types from production database..."
-          supabase gen types typescript --password ${{ secrets.SUPABASE_DB_PASSWORD }} > types/database.ts
+          supabase gen types typescript --linked --password ${{ secrets.SUPABASE_DB_PASSWORD }} > types/database.ts
           echo "✅ Types generated successfully"
         env:
           SUPABASE_ACCESS_TOKEN: ${{ secrets.SUPABASE_ACCESS_TOKEN }}


### PR DESCRIPTION
## 🔧 Fix: Add --linked flag to supabase gen types commands

This PR fixes the "Must specify one of --local, --linked, --project-id, or --db-url" error in the Deploy workflow.

### 🐛 Problem
- Deploy workflow failing with: `Must specify one of --local, --linked, --project-id, or --db-url`
- `supabase gen types typescript` command needs to specify which database to connect to
- Same issue affects both deploy and publish-types workflows

### ✅ Solution
- Added `--linked` flag to `supabase gen types` commands in both workflows
- Since we already run `supabase link --project-ref` in both workflows, using `--linked` is the correct approach
- Also ensured proper environment variables are set

### 📋 Changes
- `.github/workflows/deploy.yml`: Added `--linked --password` flags to gen types command
- `.github/workflows/publish-types.yml`: Added `--linked` flag to gen types command

### 🧪 Testing
This should now allow:
- ✅ Deploy workflow to successfully generate production types for verification
- ✅ Publish Types Package workflow to run after successful deploy
- ✅ Complete CI/CD pipeline from PR → Deploy → NPM Publish