### PR TITLE
fix: remove invalid --password flag from supabase gen types

### DIFF
--- a/.github/workflows/deploy.yml
+++ b/.github/workflows/deploy.yml
@@ -41,7 +41,7 @@ jobs:
 
       - name: Generate and verify production types
         run: |
-          supabase gen types typescript --linked --password ${{ secrets.SUPABASE_DB_PASSWORD }} > types/database-production.ts
+          supabase gen types typescript --linked > types/database-production.ts
           echo "✅ Production types generated successfully"
           # Note: We don't commit these back as they should match the committed types
           # This step is mainly for verification that production schema matches expectations

--- a/.github/workflows/publish-types.yml
+++ b/.github/workflows/publish-types.yml
@@ -57,7 +57,7 @@ jobs:
       - name: Generate types from production
         run: |
           echo "🔄 Generating types from production database..."
-          supabase gen types typescript --linked --password ${{ secrets.SUPABASE_DB_PASSWORD }} > types/database.ts
+          supabase gen types typescript --linked > types/database.ts
           echo "✅ Types generated successfully"
         env:
           SUPABASE_ACCESS_TOKEN: ${{ secrets.SUPABASE_ACCESS_TOKEN }}


### PR DESCRIPTION
## 🔧 Fix: Remove invalid --password flag from supabase gen types

**Tested locally first to save GitHub Actions minutes! ✅**

### 🐛 Problem
- `supabase gen types` command was failing with `unknown flag: --password`
- The `--password` flag is only valid for `supabase db push`, not for `supabase gen types`
- This was causing Deploy workflow to fail consistently

### ✅ Solution  
- Removed `--password` flag from `supabase gen types` commands
- Authentication is properly handled via `SUPABASE_ACCESS_TOKEN` environment variable
- Both `supabase db push` (with `--password`) and `supabase gen types` (without `--password`) work correctly

### 🧪 Local Testing Results
```bash
# This works ✅
supabase gen types typescript --linked

# This also works ✅  
supabase db push --dry-run
```

### 📋 Changes
- `.github/workflows/deploy.yml`: Removed `--password` from gen types command
- `.github/workflows/publish-types.yml`: Removed `--password` from gen types command

### 🎯 Expected Results
- ✅ Deploy workflow should succeed
- ✅ Publish Types Package workflow should run after Deploy
- ✅ Complete CI/CD pipeline: PR → Deploy → NPM Publish